### PR TITLE
Added a way to update GitHub token in DB with -github-info

### DIFF
--- a/commands/github-info.js
+++ b/commands/github-info.js
@@ -20,7 +20,11 @@ module.exports = {
                     "GitHub auth was successful. Use -help to see what actions you can now take."
                 );
             }).catch((err) => {
-                console.error(err);
+                db.updateGitHubToken(message.author.id, githubToken).then(result => {
+                    return message.reply(
+                        "Your GitHub token has been updated"
+                    );
+                })
             });
         }
     }

--- a/database.js
+++ b/database.js
@@ -58,4 +58,13 @@ async function insertGitHubToken(discord_id, github_token) {
     });
 }
 
-module.exports = { fetchGit, insertGitHubToken };
+// Update an entry with a new token if the insertGitHubToken throws an error
+async function updateGitHubToken(discord_id, github_token){
+    return await Tokens.update({token: github_token}, {
+        where: {
+            id: discord_id,
+        }
+    });
+}
+
+module.exports = { fetchGit, insertGitHubToken, updateGitHubToken };


### PR DESCRIPTION
### Why This PR Adds Value

Now the user can update their GitHub token in the database in case **they put a wrong or an old token**.

### What This PR Adds

- New function `updateGitHubToken` in `database.js`
- Different error handling for `insertGitHubToken` in `github-info.js` 

### Screenshot

![Screenshot from 2021-08-10 22-05-43](https://user-images.githubusercontent.com/62047062/128963426-1403f81f-321f-48ab-adab-7636b38c82ee.png)
![Screenshot from 2021-08-10 22-05-54](https://user-images.githubusercontent.com/62047062/128963433-4ece90ce-467a-4db8-a947-d99e862beef6.png)
![Screenshot from 2021-08-10 22-06-01](https://user-images.githubusercontent.com/62047062/128963437-8f4b1976-21d3-42bb-b154-c4e4477b1ce6.png)

### How This PR Could Be Improved

- Now we need to check if a provided GitHub is valid (looking into this atm https://github.com/octokit/auth-token.js/)

### Issue This PR Closes

This closes #62
