### PR TITLE
Main Octokit Refactoring

### DIFF
--- a/commands/github-post-comment.js
+++ b/commands/github-post-comment.js
@@ -8,18 +8,12 @@ module.exports = {
     description: "Post a comment on GitHub Issue or PR",
     usage: "-github-post-comment <organization-name> <repo-name> <issue-number> <your-comment>",
     example: "-github-post-comment MLH-Fellowship gitcord-bot 32 your comment",
-    execute(command, message, args) {
+    execute(command, message, args, octokit) {
         // -github-post-comment: Posts desired comment on previously specified issue/PR
         if (command === "github-post-comment") {
             let comment = args.slice(3);
             comment = comment.join(" ");
-            db.fetchGit(message.author.id).then((result) => {
-                let octokit = new MyOctokit({ auth: result });
-                postComment(comment, octokit);
-            }).catch((err) => {
-                console.error(err);
-                return message.reply("Your GitHub token isn't on file. Run -github-info, specifying your GitHub token (and then try this again)");
-            });
+            postComment(comment, octokit);
         }
 
         // Post Comment function

--- a/commands/github-post-comment.js
+++ b/commands/github-post-comment.js
@@ -6,7 +6,8 @@ const MyOctokit = Octokit.plugin(restEndpointMethods);
 module.exports = {
     name: "github-post-comment",
     description: "Post a comment on GitHub Issue or PR",
-    usage: "-github-post-comment <your-comment-to-be-posted>",
+    usage: "-github-post-comment <organization-name> <repo-name> <issue-number> <your-comment>",
+    example: "-github-post-comment MLH-Fellowship gitcord-bot 32 your comment",
     execute(command, message, args) {
         // -github-post-comment: Posts desired comment on previously specified issue/PR
         if (command === "github-post-comment") {

--- a/commands/github-post-standup.js
+++ b/commands/github-post-standup.js
@@ -6,7 +6,19 @@ const MyOctokit = Octokit.plugin(restEndpointMethods);
 module.exports = {
     name: "github-post-standup",
     description: "Post a comment on a GitHub discussion",
-    usage: "github-post-standup <your-comment-for-github-discussion>",
+    usage: "github-post-standup <organization-name> <team-name> <discussion-number> <your-comment>",
+    example: "\n -github-post-standup MLH-Fellowship pod-3-1-3 8 \n" +
+        "**What did you achieve in the last 24 hours?**:\n" +
+        " - \n" +
+        "\n" +
+        "**What are your priorities for the next 24 hours?**:\n" +
+        " - \n" +
+        "\n" +
+        "**Blockers**:\n" +
+        " -\n" +
+        "\n" +
+        "**Shoutouts**:\n" +
+        " - @username for x",
     execute(command, message, args) {
         // -github-post-standup: Posts desired comment on a GitHub Discussion
         if (command === "github-post-standup") {

--- a/commands/github-post-standup.js
+++ b/commands/github-post-standup.js
@@ -19,18 +19,12 @@ module.exports = {
         "\n" +
         "**Shoutouts**:\n" +
         " - @username for x",
-    execute(command, message, args) {
+    execute(command, message, args, octokit) {
         // -github-post-standup: Posts desired comment on a GitHub Discussion
         if (command === "github-post-standup") {
             let comment = args.slice(3);
             comment = comment.join(" ");
-            db.fetchGit(message.author.id).then((result) => {
-                let octokit = new MyOctokit({ auth: result });
-                postComment(comment, octokit);
-            }).catch((err) => {
-                console.error(err);
-                return message.reply("Your GitHub token isn't on file. Run -github-info, specifying your GitHub token (and then try this again)");
-            });
+            postComment(comment, octokit);
         }
 
         // Post Comment function

--- a/commands/github-projects.js
+++ b/commands/github-projects.js
@@ -7,7 +7,7 @@ module.exports = {
     name: "github-projects",
     description: "GitHub Project Functionality",
     usage: "To create a new Github project, add create followed by the owner, repo and project title (-github-project create-project repo-owner repo-name project-title).\nTo create a new column, add create-column followed by project id and name (-github-project create-column project-id column-name).",
-    execute(command, message, args) {
+    execute(command, message, args, octokit) {
         // -github-projects: Selects GitHub Project Functionality
         if (command === "github-projects") {
             switch (args[0]) {
@@ -19,13 +19,7 @@ module.exports = {
                     } else {
                         let projectTitle = args.slice(3);
                         projectTitle = projectTitle.join(" ");
-                        db.fetchGit(message.author.id).then((result) => {
-                            let octokit = new MyOctokit({ auth: result });
-                            createProject(projectTitle, octokit);
-                        }).catch((err) => {
-                            console.error(err);
-                            return message.reply("Your GitHub token isn't on file. Run -github-info, specifying your GitHub token (and then try this again)");
-                        });
+                        createProject(projectTitle, octokit);
                     }
                     break;
                 case "create-column":
@@ -36,39 +30,21 @@ module.exports = {
                     } else {
                         let columnName = args.slice(2);
                         columnName = columnName.join(" ");
-                        db.fetchGit(message.author.id).then((result) => {
-                            let octokit = new MyOctokit({ auth: result });
-                            createColumn(columnName, octokit);
-                        }).catch((err) => {
-                            console.error(err);
-                            return message.reply("Your GitHub token isn't on file. Run -github-info, specifying your GitHub token (and then try this again)");
-                        });
+                        createColumn(columnName, octokit);
                     }
                     break;
                 case "select-project":
                     if (!args[1]) {
                         return message.reply("please provide your GitHub Project ID in order to select a project.");
                     } else {
-                        db.fetchGit(message.author.id).then((result) => {
-                            let octokit = new MyOctokit({ auth: result });
-                            getProject(args[1], octokit);
-                        }).catch((err) => {
-                            console.error(err);
-                            return message.reply("Your GitHub token isn't on file. Run -github-info, specifying your GitHub token (and then try this again)");
-                        });
+                        getProject(args[1], octokit);
                     }
                     break;
                 case "select-column":
                     if (!args[1]) {
                         return message.reply("please provide your GitHub Column ID in order to select a column.");
                     } else {
-                        db.fetchGit(message.author.id).then((result) => {
-                            let octokit = new MyOctokit({ auth: result });
-                            getCards(args[1]), octokit;
-                        }).catch((err) => {
-                            console.error(err);
-                            return message.reply("Your GitHub token isn't on file. Run -github-info, specifying your GitHub token (and then try this again)");
-                        });
+                        getCards(args[1]), octokit;
                     }
                     break;
                 default:

--- a/commands/github-update-standup.js
+++ b/commands/github-update-standup.js
@@ -19,18 +19,12 @@ module.exports = {
         "\n" +
         "**Shoutouts**:\n" +
         " - @username for x",
-    execute(command, message, args) {
+    execute(command, message, args, octokit) {
         // -github-update-standup: Updates desired comment on a GitHub Discussion
         if (command === "github-update-standup") {
             let comment = args.slice(4);
             comment = comment.join(" ");
-            db.fetchGit(message.author.id).then((result) => {
-                let octokit = new MyOctokit({ auth: result });
-                postComment(comment, octokit);
-            }).catch((err) => {
-                console.error(err);
-                return message.reply("Your GitHub token isn't on file. Run -github-info, specifying your GitHub token (and then try this again)");
-            });
+            postComment(comment, octokit);
         }
 
         // Post Comment function

--- a/commands/github-update-standup.js
+++ b/commands/github-update-standup.js
@@ -6,7 +6,19 @@ const MyOctokit = Octokit.plugin(restEndpointMethods);
 module.exports = {
     name: "github-update-standup",
     description: "Update a comment on a GitHub discussion",
-    usage: "-github-update-standup <your-updated-comment>",
+    usage: "-github-update-standup <organization-name> <team-name> <discussion-number> <comment-number> <your-updated-comment>",
+    example: "\n -github-update-standup MLH-Fellowship pod-3-1-3 8 15 \n" +
+        "**What did you achieve in the last 24 hours?**:\n" +
+        " - updated note \n" +
+        "\n" +
+        "**What are your priorities for the next 24 hours?**:\n" +
+        " - updated note\n" +
+        "\n" +
+        "**Blockers**:\n" +
+        " -\n" +
+        "\n" +
+        "**Shoutouts**:\n" +
+        " - @username for x",
     execute(command, message, args) {
         // -github-update-standup: Updates desired comment on a GitHub Discussion
         if (command === "github-update-standup") {
@@ -33,7 +45,7 @@ module.exports = {
                 })
                 .then(() => {
                     return message.reply(
-                        `Your comment "${comment}" has been updated on ${args[1]}'s discussion #${args[2]}.`
+                        `Your comment \n"${comment}"\n has been updated on ${args[1]}'s discussion #${args[2]}.`
                     );
                 })
                 .catch((error) => {

--- a/commands/help.js
+++ b/commands/help.js
@@ -32,6 +32,7 @@ module.exports = {
 
         if (listCommand.description) data.push(`**Description: **${listCommand.description}`);
         if (listCommand.usage) data.push(`**Usage: **${listCommand.usage}`);
+        if (listCommand.example) data.push(`**Example: **${listCommand.example}`);
         message.reply(data, { split: true });
     },
 };

--- a/main.js
+++ b/main.js
@@ -37,7 +37,7 @@ client.on("message", (message) => {
         client.commands.get(command).execute(command, message, args);
     } catch (error) {
         console.error(error);
-        message.reply("there was an error trying to execute that command. Please try again.");
+        message.reply("There was an error trying to execute that command. Please try again.");
     }
 });
 


### PR DESCRIPTION
### Why This PR Adds Value

Instead of fetching GitHub tokens separately in each command, we only fetch it once per message to pass to a command. It is useful because it creates the Octokit object in `main.js` that is then used throughout

### What This PR Adds

- Added examples to `github-post-standup` with Swift's Standup Notes Template, `github-post-comment`, and `gthub-update-standup`
- Refactored `main.js` to fetch GitHub tokens, create Octokits, and then pass them to the commands so that it would be less code in the commands to deal with GitHub authorization

### Screenshot

![Screenshot from 2021-08-11 20-52-59](https://user-images.githubusercontent.com/62047062/129126346-16fc8327-8ceb-410e-90d3-1386b6a019a6.png)

![Screenshot from 2021-08-11 20-53-27](https://user-images.githubusercontent.com/62047062/129126378-49a0ef02-239b-415d-8f09-86b3bcff05bb.png)

Commands ran with the Octokit initialized in `main.js`

![Screenshot from 2021-08-11 20-54-11](https://user-images.githubusercontent.com/62047062/129126442-a02c149b-dd84-479e-812e-e1ccdf709d99.png)

![Screenshot from 2021-08-11 20-54-11](https://user-images.githubusercontent.com/62047062/129126470-d139c4af-e461-4ccd-811d-9d1d73c2fe36.png)

### How This PR Could Be Improved

- Right now, it still fetches a GitHub token each time a command is ran. It just saves us lines to not have to run `db.fetchGit()` in each command file (no idea how to make the Octokit instance once for all bot users) 

### Issue This PR Closes

This closes #67 