### PR TITLE
Fixed Lighthouse on Headless Servers

### DIFF
--- a/commands/lighthouse.js
+++ b/commands/lighthouse.js
@@ -3,7 +3,11 @@ const chromeLauncher = require("chrome-launcher");
 
 async function getStats(url) {
     return chromeLauncher.launch({args: ['--no-sandbox', '--disable-setuid-sandbox'],
-      chromeFlags: ["--headless"] }).then((chrome) => {
+      chromeFlags: [
+	"--headless",
+	"--no-sandbox"
+	]
+	}).then((chrome) => {
         const opts = {
             logLevel: "info",
             output: "html",


### PR DESCRIPTION
### Why This PR Adds Value

Fixes Lighthouse not working on headless servers like our Linode server. This is important since otherwise the Lighthouse command won't work on our deployed server.

### What This PR Adds

- Adds `-no-sandbox` argument to `chromeLauncher`

### Notes

Requires `chromium` package to be installed and using a non-root user

### Issue This PR Closes

This closes #69.