### PR TITLE
Avoid Fetching Tokens for New Users

### DIFF
--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ client.on("message", (message) => {
     return;
   }
 
-  if (command !== "lighthouse" && command !== "tech-stack" && command !== "help") {
+  if (command !== "lighthouse" && command !== "tech-stack" && command !== "help" && command !== "github-info") {
     try {
       db.fetchGit(message.author.id)
         .then((result) => {


### PR DESCRIPTION
### Why This PR Adds Value

As new users will be trying to set up their GitHub tokens, we cannot get their GitHub tokens in `main.js` before they put it in the database. Therefore, we need to avoid fetching GitHub tokens for those who run the `-github-info` command.

Without avoiding it, the program throws an error because the `fetchGit` returns an empty list.

### What This PR Adds

- Adds `github-info` to be avoided in `main.js` among other command who do not need the token to be run (lighthouse, tech-stack, help).

### Screenshot

Without having the token in the database, the bot won't even let me set a new token

![Screenshot from 2021-08-12 20-28-00](https://user-images.githubusercontent.com/62047062/129291958-3ad0fde7-0ce4-4a3c-8eeb-fed42657f1d4.png)

### Issue This PR Closes

This closes #80