### PR TITLE
Delete Token Command

### DIFF
--- a/commands/github-delete-token.js
+++ b/commands/github-delete-token.js
@@ -1,0 +1,22 @@
+const db = require("../database");
+
+module.exports = {
+    name: "github-delete-token",
+    description: "Deletes Your GitHub Token From Our Database Permanently",
+    usage: "-github-delete-token",
+    execute(command, message, args) {
+        if (!args.length) {
+        db.deleteGitHubToken(message.author.id).then((result) => {
+            if (result === 1) {
+                return message.reply(`Your GitHub token has been permanently deleted.`);
+            } else {
+                return message.reply(`Your GitHub token has not been deleted. This could only mean we don't have your token on file.`)
+            }
+
+        }).catch((err) => {
+            console.error(err);
+            return message.reply("Your GitHub token isn't on file. Try again, specifying your GitHub token (once you do it, we'll store it securely)");
+        });
+        }
+    }
+};

--- a/database.js
+++ b/database.js
@@ -67,4 +67,13 @@ async function updateGitHubToken(discord_id, github_token){
     });
 }
 
-module.exports = { fetchGit, insertGitHubToken, updateGitHubToken };
+// Delete an entry with user Discord ID (returns 1 if deleted, 0 if not)
+async function deleteGitHubToken(discord_id){
+    return await Tokens.destroy({
+        where: {
+            id: discord_id,
+        }
+    })
+}
+
+module.exports = { fetchGit, insertGitHubToken, updateGitHubToken, deleteGitHubToken };

--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ client.on("message", (message) => {
     return;
   }
 
-  if (command !== "lighthouse" && command !== "tech-stack" && command !== "help" && command !== "github-info") {
+  if (command !== "lighthouse" && command !== "tech-stack" && command !== "help" && command !== "github-info" && command !== 'github-delete-command') {
     try {
       db.fetchGit(message.author.id)
         .then((result) => {

--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ client.on("message", (message) => {
     return;
   }
 
-  if (command !== "lighthouse" && command !== "tech-stack" && command !== "help" && command !== "github-info" && command !== 'github-delete-command') {
+  if (command !== "lighthouse" && command !== "tech-stack" && command !== "help" && command !== "github-info" && command !== 'github-delete-token') {
     try {
       db.fetchGit(message.author.id)
         .then((result) => {

--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ client.on("message", (message) => {
     return;
   }
 
-  if (command !== "lighthouse" && command !== "tech-stack" && command !== "help") {
+  if (command !== "lighthouse" && command !== "tech-stack" && command !== "help" && command !== "github-info") {
     try {
       db.fetchGit(message.author.id)
         .then((result) => {


### PR DESCRIPTION
### Why This PR Adds Value

It's important to keep our user's data secure. Therefore, we must give them an option to completely wipe their GitHub tokens with a single command `-github-delete-token`.

### What This PR Adds

- It modifies `main.js` to avoid fetching GitHub tokens before executing the command (that way it throws a different error)
- It adds a new function in `database.js` to delete GitHub tokens based on Discord ID
- It adds a new command file `github-delete-token.js` that uses the above mentioned function and deals with the output **(1 if deleted, 0 if not)**
- The branch `delete-command` considered the previous branch `new-user-fetch` for easier merging

### Screenshot

![Screenshot from 2021-08-12 20-45-16](https://user-images.githubusercontent.com/62047062/129293308-49818af3-9bea-46f5-bf5c-676e02ac5cf7.png)
![Screenshot from 2021-08-12 20-46-12](https://user-images.githubusercontent.com/62047062/129293323-36ca30b6-89cd-4a5d-928a-a7d235763cae.png)

### Issue This PR Closes

This closes #82